### PR TITLE
Added bioconductor fields and package coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,5 @@
+^codecov\.yml$
+^appveyor\.yml$
+^\.travis\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,11 +8,14 @@ Description:
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
+biocViews:
 Depends:
     dplyr,
     purrr,
     covr,
-    tools
+    tools,
+Imports: 
+    BiocPkgTools
 RoxygenNote: 6.1.1
 Suggests: 
     knitr,

--- a/R/riskmetric.R
+++ b/R/riskmetric.R
@@ -2,16 +2,22 @@
 #'
 #' Temporary Function, under development
 get_riskmetric <- function(){
-  cran_db    <- tools::CRAN_package_db()
-  cran_db1    <- cran_db[, c("Package", "Version", "License", "Copyright", "Author", "BugReports",
-                             "Maintainer", "Published", "Title", "URL")]
+  cran_db <- tools::CRAN_package_db()
+  cran_db1 <- cran_db[, c("Package", "Version", "License", "Copyright",
+    "Author", "BugReports", "Maintainer", "Published", "Title", "URL")]
+
+  bioc_db <- BiocPkgTools::biocPkgList()
+  bioc_db1 <- bioc_db[, c("Package", "Version", "License", # Copyright not available
+    "Author", "BugReports", "Maintainer", "Date/Publication", "Title", "URL")]
+  bioc_db1$Author <- sapply(bioc_db1$Author, paste, collapse = ", ")
+  bioc_db1$Maintainer <- sapply(bioc_db1$Maintainer, paste, collapse = ", ")
 
   riskmetric <- tibble(Package = c("dplyr", "emmeans", "haven", "gsDesign","limma"),
                        Source  = c(rep("CRAN",4), "Bioconductor"),
                        # It will be Y for base and recommended R package in R-FDA.pdf
                        `21CFR` = rep("N", 5),
                        # Code coverage. This is an estimation for proof of concept only.
-                       Codecov = c(83, NA,  88, 25, NA),
+                       Codecov = c(83, 8,  88, 25, NA),
                        # Wheather the R pacakge had at least one Vignettes
                        Vignettes = rep("Y", 5),
                        # Wheather the R package had News to track changes of version
@@ -30,10 +36,9 @@ get_riskmetric <- function(){
   depends <- tools::package_dependencies(riskmetric$Package,recursive = TRUE)
 
   riskmetric <- riskmetric %>%
-    merge(cran_db1, all.x = TRUE) %>%
+    left_join(bind_rows(cran_db1, bioc_db1), by = "Package") %>%
     mutate(dependency = depends)
 
   saveRDS(riskmetric, "data/riskmetric.Rd")
+  invisible(riskmetric)
 }
-
-

--- a/R/riskmetric.R
+++ b/R/riskmetric.R
@@ -1,6 +1,11 @@
 #' Get Risk Metric
 #'
 #' Temporary Function, under development
+#'
+#' @import dplyr
+#' @importFrom tools CRAN_package_db package_dependencies
+#' @importFrom BiocPkgTools biocPkgList
+#'
 get_riskmetric <- function(){
   cran_db <- tools::CRAN_package_db()
   cran_db1 <- cran_db[, c("Package", "Version", "License", "Copyright",

--- a/R/riskmetric.R
+++ b/R/riskmetric.R
@@ -5,6 +5,7 @@
 #' @import dplyr
 #' @importFrom tools CRAN_package_db package_dependencies
 #' @importFrom BiocPkgTools biocPkgList
+#' @importFrom BiocManager repositories
 #'
 get_riskmetric <- function(){
   cran_db <- tools::CRAN_package_db()
@@ -38,7 +39,10 @@ get_riskmetric <- function(){
                        # Wheather the R pacakge require other language, e.g. Java, C++, Fortune
                        External_language = NA)
 
-  depends <- tools::package_dependencies(riskmetric$Package,recursive = TRUE)
+  depends <- tools::package_dependencies(
+    riskmetric$Package,
+    recursive = TRUE,
+    db = utils::available.packages(repos = BiocManager::repositories()))
 
   riskmetric <- riskmetric %>%
     left_join(bind_rows(cran_db1, bioc_db1), by = "Package") %>%

--- a/R/riskmetric.R
+++ b/R/riskmetric.R
@@ -47,7 +47,13 @@ get_riskmetric <- function(){
 
   riskmetric <- riskmetric %>%
     left_join(bind_rows(cran_db1, bioc_db1), by = "Package") %>%
-    mutate(dependency = depends)
+    mutate(dependency = depends) %>%
+    mutate(Author = lapply(
+      # split on any commas not between square brackets
+      strsplit(Author, "(,)(?![^[]*\\])", perl = TRUE),
+      # trim surrounding whitespace and replace enclosed newlines with spaces
+      . %>% trimws %>% gsub(pattern = "\n", replacement = " ")
+    ))
 
   saveRDS(riskmetric, "data/riskmetric.Rd")
   invisible(riskmetric)


### PR DESCRIPTION
### Changes
* added `emmeans` code coverage
* used `BiocPkgTools::biocPkgList` to get analogous fields as CRAN db

### Needs work:
* haven't yet re-generated dataset for package, wasn't sure how we wanted to version this on GitHub
* `Copyright` isn't an avaialble field from `biocPkgList`
* `limma` doesn't use a testing framework I'm familiar with, not sure how to test it