### PR TITLE
Added handling of get_cran_version for vector of package names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: riskmetric
 Type: Package
 Title: Risk Metrics to Evaluatin R Packages
-Description: todo
+Description: A package to facilitate the assessment of risk associated with 
+    R package use within a pharmaceutical regulatory context.
 Version: 0.1.0.9000
 Author: Who wrote it
 Maintainer: The package maintainer <yourself@somewhere.net>

--- a/R/cran.R
+++ b/R/cran.R
@@ -1,16 +1,13 @@
 #' Get current CRAN version
 #'
-#' @param pkgname character, package name
+#' @param pkgname a character vector of names of packages
+#' @return a character vector of version numbers of respective packages
 #'
 #' @usage
-#' get_cran_version("dplyr")
+#' get_cran_version(c("dplyr", "tidyverse"))
 #'
 #' @export
+#'
 get_cran_version <- function(pkgname) {
-
-  package <- NULL # avoid CRAN check note on NSE
-  memoise_cran_db() %>%
-    filter(package == pkgname) %>%
-    pull(version)
-
+  with(memoise_cran_db(), version[match(pkgname, package)])
 }

--- a/R/cran.R
+++ b/R/cran.R
@@ -3,7 +3,7 @@
 #' @param pkgname a character vector of names of packages
 #' @return a character vector of version numbers of respective packages
 #'
-#' @usage
+#' @examples
 #' get_cran_version(c("dplyr", "tidyverse"))
 #'
 #' @export

--- a/man/get_cran_version.Rd
+++ b/man/get_cran_version.Rd
@@ -7,8 +7,15 @@
 get_cran_version(pkgname)
 }
 \arguments{
-\item{pkgname}{character, package name}
+\item{pkgname}{a character vector of names of packages}
+}
+\value{
+a character vector of version numbers of respective packages
 }
 \description{
 Get current CRAN version
+}
+\examples{
+get_cran_version(c("dplyr", "tidyverse"))
+
 }

--- a/riskmetric.Rproj
+++ b/riskmetric.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test_cran_metrics.R
+++ b/tests/testthat/test_cran_metrics.R
@@ -1,21 +1,10 @@
 context("Test CRAN related metrics")
 
 test_that("CRAN current version returns correct format", {
+  expect_match(get_cran_version("dplyr"), "\\d+(\\.\\d+){2,3}")
+  expect_match(get_cran_version("tidyverse"), "\\d+(\\.\\d+){2,3}")
+})
 
-    expect_equal(
-      grep(
-        "\\d+(\\.\\d+){2,3}",
-        get_cran_version("dplyr")
-      ),
-      1
-    )
-
-    expect_equal(
-      grep(
-        "\\d+(\\.\\d+){2,3}",
-        get_cran_version("tidyverse")
-      ),
-      1
-    )
-
+test_that("CRAN version metric works with character vector input.", {
+  expect_length(get_cran_version(c("dplyr", "tidyverse")), 2)
 })

--- a/tests/testthat/test_cran_metrics.R
+++ b/tests/testthat/test_cran_metrics.R
@@ -5,6 +5,14 @@ test_that("CRAN current version returns correct format", {
   expect_match(get_cran_version("tidyverse"), "\\d+(\\.\\d+){2,3}")
 })
 
-test_that("CRAN version metric works with character vector input.", {
+test_that("CRAN version metric works with character vector input", {
   expect_length(get_cran_version(c("dplyr", "tidyverse")), 2)
+})
+
+test_that("CRAN version metric returns NA for missing packages", {
+  expect_equal({
+    get_cran_version(c("dplyr", "tidyverse", "zxyabczxy"))[[3]]
+  }, {
+    NA_character_
+  })
 })


### PR DESCRIPTION
I figured if we're operating on the `cran_db` data.frame that it would be good to be able to accommodate a situation where we want to pull a whole vector of version numbers. 

I also updated the test suite with a couple more tests to accommodate the new behavior. 