### PR TITLE
made package references environments for call by reference behaviour

### DIFF
--- a/R/pkg_ref.R
+++ b/R/pkg_ref.R
@@ -81,10 +81,10 @@ pkg_ref <- function(name, source, ...) {
     c("pkg_remote", "pkg_install", "pkg_source", "pkg_missing"),
     several.ok = FALSE)
 
-  pkg_data <- append(list(
+  pkg_data <- as.environment(append(list(
     name = name,
     source = source
-  ), dots)
+  ), dots))
 
-  structure(pkg_data, class = c(source, "pkg_ref"))
+  structure(pkg_data, class = c(source, "pkg_ref", "environment"))
 }


### PR DESCRIPTION
That's pretty much it, all there is to mimic call by reference. #20
Now you can basically store whatever you want in a pkg_reference and it should never get copied when you pass the thing around!