### PR TITLE
added get/set functions to improve environment namespace maintainability

### DIFF
--- a/R/get_metrics.R
+++ b/R/get_metrics.R
@@ -1,0 +1,23 @@
+
+get_metrics <- function(pkgs) {
+  if (!exists(pkgs))
+    pkgs <- c(
+      get_cran_packages()
+      #get_bioconductor_packages()
+    )
+
+}
+
+
+get_cran_packages <- function(pkgs, repo = "https://cran.r-project.com") {
+  Map(function(pkg, version) {
+    structure(pkg,
+      repo = "cran.r-project.org",
+      source = sprintf(
+        "%s/src/contrib/%s_%s.tar.gz",
+        repo,
+        pkg,
+        version),
+      class = c("cran_package_ref", "package_ref", "character"))
+  }, memoise_cran_db()$packages, memoise_cran_db()$version)
+}

--- a/R/pkg_ref.R
+++ b/R/pkg_ref.R
@@ -81,7 +81,6 @@ pkg_ref <- function(name, source, ...) {
   structure(pkg_data, class = c(source, "pkg_ref", "environment"))
 }
 
-pairlist(a = , b = )
 
 
 #' List of variables with which to prepopulate a pkg_ref environment

--- a/R/pkg_ref.R
+++ b/R/pkg_ref.R
@@ -81,6 +81,7 @@ pkg_ref <- function(name, source, ...) {
   structure(pkg_data, class = c(source, "pkg_ref", "environment"))
 }
 
+pairlist(a = , b = )
 
 
 #' List of variables with which to prepopulate a pkg_ref environment
@@ -89,12 +90,11 @@ pkg_ref <- function(name, source, ...) {
 #' \code{$get} and \code{$set} functions. If new fields are required, please add
 #' them here so that they can be controlled in a single place.
 #'
-pkg_env_fields <- function() {
-  list(
-    name = NULL,
-    source = NULL,
-    path = NULL)
-}
+pkg_env_fields <- function() { list(
+  name = NULL,
+  source = NULL,
+  path = NULL
+) }
 
 
 
@@ -107,10 +107,19 @@ pkg_env_fields <- function() {
 new_pkg_env <- function(...) {
   pkg_env <- as.environment(pkg_env_fields())
 
+  # namespace-validated shorthand for checking if variable is not NULL
+  pkg_env$has <- function(var) {
+    if (!exists(var, envir = pkg_env))
+      stop(sprintf('"%s" is not a valid package environment variable'))
+    !is.null(pkg_env[[var]])
+  }
+
   # build package getter function, validating against variable names
-  pkg_env$get <- function(var) {
-    if (exists(var, envir = pkg_env)) return(pkg_env[[var]])
-    else stop(sprintf('"%s" is not a valid package environment variable', var))
+  pkg_env$get <- function(var, default) {
+    if (!exists(var, envir = pkg_env))
+      stop(sprintf('"%s" is not declared in this package environemnt', var))
+    else if (missing(default)) return(pkg_env[[var]])
+    else return(default)
   }
 
   # build package setter function, restricting variable names

--- a/R/pkg_ref.R
+++ b/R/pkg_ref.R
@@ -77,8 +77,7 @@ pkg_ref <- function(name, source, ...) {
     c("pkg_remote", "pkg_install", "pkg_source", "pkg_missing"),
     several.ok = FALSE)
 
-  pkg_data <- new_pkg_env()
-  pkg_data$set(name = name, source = source, ...)
+  pkg_data <- new_pkg_env(name = name, source = source, ...)
   structure(pkg_data, class = c(source, "pkg_ref", "environment"))
 }
 
@@ -105,7 +104,7 @@ pkg_env_fields <- function() {
 #'   \code{pkg_env_fields}, including a \code{$get} and \code{$set} method for
 #'   retrieving values and modifying values
 #'
-new_pkg_env <- function() {
+new_pkg_env <- function(...) {
   pkg_env <- as.environment(pkg_env_fields())
 
   # build package getter function, validating against variable names
@@ -137,5 +136,6 @@ new_pkg_env <- function() {
   }
 
   lockEnvironment(pkg_env)
+  pkg_env$set(...)
   pkg_env
 }


### PR DESCRIPTION
added function `new_pkg_env` to instantiate a new package environment, this environment is locked and contains:
* prepopulated variables based on the `pkg_env_fields` list, so that any changes to what variables we should expect in the namespace can be declared in one place
* a `get` function, which validates against the existing variable names to make sure you're requesting a viable variable, can take a `default` argument to fall back to if a variable hasn't been set yet.
* a `set` function which validates against the existing variable names before unlocking the namespace, assigning the new value and re-locking. 
* a `has` function to check if a variable has a value.

With these guardrails in place, I feel a lot more comfortable about using namespaces to accumulate package metadata and mitigate repeated calls to access it.