### PR TITLE
add pkg_ref_cache.help_aliases.pkg_source fn

### DIFF
--- a/R/pkg_ref_cache_help_aliases.R
+++ b/R/pkg_ref_cache_help_aliases.R
@@ -22,8 +22,9 @@ pkg_ref_cache.help_aliases.pkg_source <- function (x, name, ...) {
                                                 rd [grep("^\\\\alias", rd)]))
                       man_name <- strsplit (strsplit (i, "\\/man\\/") [[1]] [2],
                                             "\\.Rd") [[1]]
-                      names (a) <- rep (man_name, length (a))
-                      return (a)    })
+                      man_name <- rep (man_name, length (a))
+                      names (man_name) <- a
+                      return (man_name)    })
   # !duplicated because unique removes names
   unlist(aliases)[!duplicated(unlist(aliases))]
 }

--- a/R/pkg_ref_cache_help_aliases.R
+++ b/R/pkg_ref_cache_help_aliases.R
@@ -12,3 +12,18 @@ pkg_ref_cache.help_aliases <- function(x, name, ...) {
 pkg_ref_cache.help_aliases.pkg_install <- function(x, name, ...) {
   readRDS(file.path(x$path, "help", "aliases.rds"))
 }
+
+pkg_ref_cache.help_aliases.pkg_source <- function (x, name, ...) {
+  f <- list.files(file.path(x$path, "man"), full.names = TRUE)
+  f <- f[grep("\\.Rd$", f)]
+  aliases <- lapply(f, function(i) {
+                      rd <- readLines(i)
+                      a <- gsub("\\}", "", gsub("\\\\alias\\{", "",
+                                                rd [grep("^\\\\alias", rd)]))
+                      man_name <- strsplit (strsplit (i, "\\/man\\/") [[1]] [2],
+                                            "\\.Rd") [[1]]
+                      names (a) <- rep (man_name, length (a))
+                      return (a)    })
+  # !duplicated because unique removes names
+  unlist(aliases)[!duplicated(unlist(aliases))]
+}


### PR DESCRIPTION
Hi @dgkf and others - great package! In my initial playing around, i noticed that the help assessment only worked for `pkg_install`, and just errored for `pkg_source`. This is an initial step to extract help aliases for the latter. It then just needs to be plugged in to a matching [`assess_export_help.pkg_source` function](https://github.com/pharmaR/riskmetric/blob/master/R/assess_export_help.R#L18) and should work, but I thought I'd leave this initial PR lightweight to start with.