### PR TITLE
tiny vignette tidying

### DIFF
--- a/vignettes/extending-riskmetric.Rmd
+++ b/vignettes/extending-riskmetric.Rmd
@@ -81,7 +81,7 @@ assess_name_first_letter <- function(x, ...) {
 attr(assess_name_first_letter, "column_name") <- "name_first_letter"
 
 assess_name_first_letter.pkg_ref <- function(x, ...) {
-  new_pkg_metric(substr(x$name, 0, 1), class = "pkg_metric_name_first_letter")
+  pkg_metric(substr(x$name, 0, 1), class = "pkg_metric_name_first_letter")
 } 
 ```
 

--- a/vignettes/riskmetric.Rmd
+++ b/vignettes/riskmetric.Rmd
@@ -105,7 +105,9 @@ processed by chaining these foundational operations. These verbs, as well as
 many of the features of package assessment, are designed to be highly extensible
 to make it easier for package validation to be a community effort.
 
-> See the `extending-riskmetric` vignette for more details
+See the
+[`extending-riskmetric`](https://pharmar.github.io/riskmetric/articles/extending-riskmetric.html)
+vignette for more details
 
 ## Creating a Package Reference 
 


### PR DESCRIPTION
The main vignette one is just because it was confusingly formatted as a quote (and i took the opportunity to insert a hyperlink there).

The change in the extending vignette is important, because i read the previous version and though, oh, okay, `new_pkg_metric()` must be a function that i have to subsequently define somewhere. But no, it actually should be the generic `pkg_metric()`, with the function named after the class (`"pkg_metric_name_first_letter"`), and subsequently defined as a template specification on [`score`](https://github.com/pharmaR/riskmetric/blob/master/vignettes/extending-riskmetric.Rmd#L188-L190) - right? Happy to iterate if i have misunderstood ...