### PR TITLE
use upper-case description filename; Fixes #106

### DIFF
--- a/R/pkg_ref_cache_DESCRIPTION.R
+++ b/R/pkg_ref_cache_DESCRIPTION.R
@@ -10,11 +10,11 @@ pkg_ref_cache.description <- function(x, name, ...) {
 
 
 pkg_ref_cache.description.pkg_install <- function(x, name, ...) {
-  read.dcf(file.path(x$path, "description"))
+  read.dcf(file.path(x$path, "DESCRIPTION"))
 }
 
 
 
 pkg_ref_cache.description.pkg_source <- function(x, name, ...) {
-  read.dcf(file.path(x$path, "description"))
+  read.dcf(file.path(x$path, "DESCRIPTION"))
 }


### PR DESCRIPTION
- changed expected description file name from "description" to "DESCRIPTION"
- tested on macos (not-case sensitive file system) and linux (case-sensitive file system) to confirm changes work as expected on all platforms