### PR TITLE
Remove rvest

### DIFF
--- a/R/pkg_ref_cache_archive_release_date.R
+++ b/R/pkg_ref_cache_archive_release_date.R
@@ -12,7 +12,7 @@ pkg_ref_cache.archive_release_dates.pkg_cran_remote <- function(x, name, ...) {
   url <- sprintf("%s/src/contrib/Archive/%s", x$repo_base_url, x$name)
 
   html <- xml2::read_html(url)
-  node <- rvest::html_node(html, "pre")
+  node <- xml2::xml_find_first(html, "//pre")
 
   text <- unlist(strsplit(rvest::html_text(node), "\n"))
   db   <- do.call(rbind, strsplit(text[-1], "\\s+"))

--- a/R/pkg_ref_cache_archive_release_date.R
+++ b/R/pkg_ref_cache_archive_release_date.R
@@ -14,7 +14,7 @@ pkg_ref_cache.archive_release_dates.pkg_cran_remote <- function(x, name, ...) {
   html <- xml2::read_html(url)
   node <- xml2::xml_find_first(html, "//pre")
 
-  text <- unlist(strsplit(rvest::html_text(node), "\n"))
+  text <- unlist(strsplit(xml2::xml_text(node), "\n"))
   db   <- do.call(rbind, strsplit(text[-1], "\\s+"))
   version <- package_version(gsub(paste0(x$name, "_(.*)\\.tar\\.gz"), "\\1", db[,2]))
   version <- as.character(version)

--- a/R/pkg_ref_cache_maintainer.R
+++ b/R/pkg_ref_cache_maintainer.R
@@ -11,7 +11,7 @@ pkg_ref_cache.maintainer <- function(x, name, ...) {
 
 pkg_ref_cache.maintainer.pkg_remote <- function(x, name, ...) {
   maintainer_xpath <- "//td[.='Maintainer:']/following::td[1]"
-  maintainer <- xml_text(xml_find_all(x$web_html, maintainer_xpath))
+  maintainer <- xml2::xml_text(xml2::xml_find_all(x$web_html, maintainer_xpath))
   maintainer
 }
 

--- a/R/pkg_ref_cache_maintainer.R
+++ b/R/pkg_ref_cache_maintainer.R
@@ -10,8 +10,8 @@ pkg_ref_cache.maintainer <- function(x, name, ...) {
 
 
 pkg_ref_cache.maintainer.pkg_remote <- function(x, name, ...) {
-  db  <- rvest::html_table(x$web_html)[[1]]
-  maintainer <- db[grep("Maintainer",db[,1], ignore.case = TRUE) ,2]
+  maintainer_xpath <- "//td[.='Maintainer:']/following::td[1]"
+  maintainer <- xml_text(xml_find_all(x$web_html, maintainer_xpath))
   maintainer
 }
 

--- a/R/pkg_ref_cache_release_date.R
+++ b/R/pkg_ref_cache_release_date.R
@@ -10,7 +10,7 @@ pkg_ref_cache.release_date <- function(x, name, ...) {
 
 pkg_ref_cache.release_date.pkg_remote <- function(x, name, ...) {
   release_xpath <- "//td[.='Published:']/following::td[1]"
-  date <- xml_text(xml_find_all(x$web_html, release_xpath))
+  date <- xml2::xml_text(xml2::xml_find_all(x$web_html, release_xpath))
   date
 }
 

--- a/R/pkg_ref_cache_release_date.R
+++ b/R/pkg_ref_cache_release_date.R
@@ -9,9 +9,8 @@ pkg_ref_cache.release_date <- function(x, name, ...) {
 
 
 pkg_ref_cache.release_date.pkg_remote <- function(x, name, ...) {
-
-  db  <- rvest::html_table(x$web_html)[[1]]
-  date <- db[grep("Publish",db[,1], ignore.case = TRUE) ,2]
+  release_xpath <- "//td[.='Published:']/following::td[1]"
+  date <- xml_text(xml_find_all(x$web_html, release_xpath))
   date
 }
 

--- a/R/pkg_ref_cache_website_urls.R
+++ b/R/pkg_ref_cache_website_urls.R
@@ -10,8 +10,8 @@ pkg_ref_cache.website_urls <- function(x, name, ...) {
 
 
 pkg_ref_cache.website_urls.pkg_remote <- function(x, name, ...) {
-  db  <- rvest::html_table(x$web_html)[[1]]
-  url <- db[grep("URL",db[,1], ignore.case = TRUE) ,2]
+  url_xpath <- "//td[.='URL:']/following::td[1]/a"
+  url  <- xml_text(xml_find_all(x$web_html, url_xpath))
   if(length(url) == 0) return(character(0L))
   url
 }

--- a/R/pkg_ref_cache_website_urls.R
+++ b/R/pkg_ref_cache_website_urls.R
@@ -11,7 +11,7 @@ pkg_ref_cache.website_urls <- function(x, name, ...) {
 
 pkg_ref_cache.website_urls.pkg_remote <- function(x, name, ...) {
   url_xpath <- "//td[.='URL:']/following::td[1]/a"
-  url  <- xml_text(xml_find_all(x$web_html, url_xpath))
+  url  <- xml2::xml_text(xml2::xml_find_all(x$web_html, url_xpath))
   if(length(url) == 0) return(character(0L))
   url
 }

--- a/tests/testthat/test_assess_export_help.R
+++ b/tests/testthat/test_assess_export_help.R
@@ -1,0 +1,10 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+test_source_2 <- pkg_ref("test_package_2")
+assess_source_2 <- assess(test_source_2)
+
+test_that("assess_export_help returns expected result for source packages", {
+  # Commenting these out until this is implemented for sourced packages
+#  expect_true(test_source_1$export_help[[1]])
+#  expect_false(test_source_2$export_help[[1]])
+})

--- a/tests/testthat/test_assess_has_news.R
+++ b/tests/testthat/test_assess_has_news.R
@@ -1,0 +1,10 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+test_source_2 <- pkg_ref("test_package_2")
+assess_source_2 <- assess(test_source_2)
+
+test_that("assess_has_news returns expected result for source packages", {
+  # TODO: add other package types
+  expect_equal(unclass(assess_source_1$has_news[[1]]), 1)
+  expect_equal(unclass(assess_source_2$has_news[[1]]), 0)
+})

--- a/tests/testthat/test_assess_has_vignettes.R
+++ b/tests/testthat/test_assess_has_vignettes.R
@@ -1,0 +1,10 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+test_source_2 <- pkg_ref("test_package_2")
+assess_source_2 <- assess(test_source_2)
+
+test_that("assess_has_vignettes returns the expected result for sourced packages", {
+
+  expect_equal(unclass(assess_source_1$has_vignettes[[1]]), 2)
+  expect_equal(unclass(assess_source_2$has_vignettes[[1]]), 0)
+})

--- a/tests/testthat/test_assess_last_30_bugs_status.R
+++ b/tests/testthat/test_assess_last_30_bugs_status.R
@@ -1,0 +1,8 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+
+test_that("assess_last_30_bugs_status returns expected result for source package", {
+  # TODO: add other package types
+  # This is calling github.com/elimillera/test_package_1/issues
+  expect_equal(unclass(assess_source_1$bugs_status[[1]]), c(FALSE, TRUE, FALSE))
+})

--- a/tests/testthat/test_assess_license.R
+++ b/tests/testthat/test_assess_license.R
@@ -1,0 +1,10 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+test_source_2 <- pkg_ref("test_package_2")
+assess_source_2 <- assess(test_source_2)
+
+test_that("assess_license returns the expected result for soruced packages", {
+
+  expect_equal(unclass(assess_source_1$license[[1]]), "MIT + file LICENSE")
+  expect_equal(unclass(assess_source_2$license[[1]]), "CC BY 2.0")
+})

--- a/tests/testthat/test_assess_news_current.R
+++ b/tests/testthat/test_assess_news_current.R
@@ -1,0 +1,10 @@
+test_source_1 <- pkg_ref("test_package_1")
+assess_source_1 <- assess(test_source_1)
+test_source_2 <- pkg_ref("test_package_2")
+assess_source_2 <- assess(test_source_2)
+
+test_that("assess_news_current returns expected result for source packages", {
+  # TODO: Add other pkg_ref types
+  expect_true(assess_source_1$news_current[[1]])
+  expect_length(assess_source_2$news_current[[1]], 0)
+})

--- a/tests/testthat/test_package_1/DESCRIPTION
+++ b/tests/testthat/test_package_1/DESCRIPTION
@@ -1,0 +1,13 @@
+Package: test_package_1
+Title: A Test Package Used to Test Source Assessments
+Version: 0.1.0
+Authors@R: "Eli Miller <first.last@example.com> [aut, cre]"
+Description: What the package does (one paragraph)
+BugReports: https://github.com/elimillera/test_package_1/issues
+Depends:
+    R (>= 3.1.2)
+License: MIT + file LICENSE
+LazyData: true
+Suggests:
+    testthat
+RoxygenNote: 5.0.1

--- a/tests/testthat/test_package_1/NAMESPACE
+++ b/tests/testthat/test_package_1/NAMESPACE
@@ -1,0 +1,1 @@
+export(test)

--- a/tests/testthat/test_package_1/NEWS.md
+++ b/tests/testthat/test_package_1/NEWS.md
@@ -1,0 +1,2 @@
+# 0.1.0
+There is no news. This is a test file to determine if the assessments are working.

--- a/tests/testthat/test_package_1/R/NAMESPACE
+++ b/tests/testthat/test_package_1/R/NAMESPACE
@@ -1,0 +1,1 @@
+export(a_test)

--- a/tests/testthat/test_package_1/R/test.R
+++ b/tests/testthat/test_package_1/R/test.R
@@ -1,0 +1,11 @@
+
+
+#' A Test function
+#'
+#' @param x An object to print
+#'
+#' @return Nothing
+#' @export
+a_test <- function(x) {
+  print(paste0("hello world", x))
+}

--- a/tests/testthat/test_package_1/man/test.Rd
+++ b/tests/testthat/test_package_1/man/test.Rd
@@ -1,0 +1,15 @@
+\name{test}
+\title{A test title}
+\usage{
+test(x)
+}
+\arguments{
+\item{x}{an object}
+}
+\value{
+the result of \code{expr}
+}
+\description{
+a wrapper to assert that a pkg_ref has been permitted to do an additional
+mutation, used to handle recursive initialization of cached fields
+}

--- a/tests/testthat/test_package_2/DESCRIPTION
+++ b/tests/testthat/test_package_2/DESCRIPTION
@@ -1,0 +1,12 @@
+Package: test_package_2
+Title: A Test Package Used to Test Source Assessments
+Version: 0.0.0.9000
+Authors@R: "Eli Miller <first.last@example.com> [aut, cre]"
+Description: What the package does (one paragraph)
+Depends:
+    R (>= 3.1.2)
+License: CC BY 2.0
+LazyData: true
+Suggests:
+    testthat
+RoxygenNote: 5.0.1

--- a/tests/testthat/test_package_2/R/NAMESPACE
+++ b/tests/testthat/test_package_2/R/NAMESPACE
@@ -1,0 +1,1 @@
+export(a_test)

--- a/tests/testthat/test_package_2/R/test.R
+++ b/tests/testthat/test_package_2/R/test.R
@@ -1,0 +1,11 @@
+
+
+#' A Test function
+#'
+#' @param x An object to print
+#'
+#' @return Nothing
+#' @export
+a_test <- function(x) {
+  print(paste0("hello world", x))
+}


### PR DESCRIPTION
Per #127, This removes all rvest functions from the package and replaces them with xml2 and predicates. The logic for all of these comes from the bug_reports file. I tested it on a couple package and it all looks good to me.

There are a bunch of other things in the test directory that I have another PR for so we might want to wait to merge this in until that has gone through.

Example:
`
> coin_ref <- pkg_ref("coin")
> head(coin_ref$archive_release_dates)
     name   version  date        
[1,] "coin" "0.2.10" "2005-05-04"
[2,] "coin" "0.2.11" "2005-06-02"
[3,] "coin" "0.2.12" "2005-06-15"
[4,] "coin" "0.2.13" "2005-07-11"
[5,] "coin" "0.2.14" "2005-07-26"
[6,] "coin" "0.2.6"  "2005-02-25"
> coin_ref$maintainer
[1] "Torsten Hothorn  <Torsten.Hothorn at R-project.org>"
> coin_ref$release_date
[1] "2019-08-28"
> coin_ref$website_urls
[1] "http://coin.r-forge.r-project.org"
`

This closes #127 