### PR TITLE
Getting unit tests passing again

### DIFF
--- a/R/cran.R
+++ b/R/cran.R
@@ -9,5 +9,5 @@
 #' @export
 #'
 get_cran_version <- function(pkgname) {
-  with(memoise_cran_db(), version[match(pkgname, package)])
+  with(memoise_cran_db(), Version[match(pkgname, Package)])
 }

--- a/tests/testthat/test_assess_export_help.R
+++ b/tests/testthat/test_assess_export_help.R
@@ -1,10 +1,10 @@
 test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
+assess_source_1 <- pkg_assess(test_source_1)
 test_source_2 <- pkg_ref("test_package_2")
-assess_source_2 <- assess(test_source_2)
+assess_source_2 <- pkg_assess(test_source_2)
 
-test_that("assess_export_help returns expected result for source packages", {
-  # Commenting these out until this is implemented for sourced packages
-#  expect_true(test_source_1$export_help[[1]])
-#  expect_false(test_source_2$export_help[[1]])
-})
+# Commenting these out until this is implemented for sourced packages
+# test_that("assess_export_help returns expected result for source packages", {
+#   expect_true(assess_source_1$export_help[[1]])
+#   expect_false(assess_source_2$export_help[[1]])
+# })

--- a/tests/testthat/test_assess_has_news.R
+++ b/tests/testthat/test_assess_has_news.R
@@ -1,7 +1,7 @@
-test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
-test_source_2 <- pkg_ref("test_package_2")
-assess_source_2 <- assess(test_source_2)
+test_source_1 <- pkg_ref("./test_package_1")
+assess_source_1 <- pkg_assess(test_source_1)
+test_source_2 <- pkg_ref("./test_package_2")
+assess_source_2 <- pkg_assess(test_source_2)
 
 test_that("assess_has_news returns expected result for source packages", {
   # TODO: add other package types

--- a/tests/testthat/test_assess_has_vignettes.R
+++ b/tests/testthat/test_assess_has_vignettes.R
@@ -1,7 +1,7 @@
-test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
-test_source_2 <- pkg_ref("test_package_2")
-assess_source_2 <- assess(test_source_2)
+test_source_1 <- pkg_ref("./test_package_1")
+assess_source_1 <- pkg_assess(test_source_1)
+test_source_2 <- pkg_ref("./test_package_2")
+assess_source_2 <- pkg_assess(test_source_2)
 
 test_that("assess_has_vignettes returns the expected result for sourced packages", {
 

--- a/tests/testthat/test_assess_last_30_bugs_status.R
+++ b/tests/testthat/test_assess_last_30_bugs_status.R
@@ -1,8 +1,8 @@
-test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
+test_source_1 <- pkg_ref("./test_package_1")
+assess_source_1 <- pkg_assess(test_source_1)
 
 test_that("assess_last_30_bugs_status returns expected result for source package", {
   # TODO: add other package types
   # This is calling github.com/elimillera/test_package_1/issues
-  expect_equal(unclass(assess_source_1$bugs_status[[1]]), c(FALSE, TRUE, FALSE))
+  expect_equal(as.vector(assess_source_1$bugs_status), c(FALSE, TRUE, FALSE))
 })

--- a/tests/testthat/test_assess_license.R
+++ b/tests/testthat/test_assess_license.R
@@ -1,7 +1,7 @@
-test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
-test_source_2 <- pkg_ref("test_package_2")
-assess_source_2 <- assess(test_source_2)
+test_source_1 <- pkg_ref("./test_package_1")
+assess_source_1 <- pkg_assess(test_source_1)
+test_source_2 <- pkg_ref("./test_package_2")
+assess_source_2 <- pkg_assess(test_source_2)
 
 test_that("assess_license returns the expected result for soruced packages", {
 

--- a/tests/testthat/test_assess_news_current.R
+++ b/tests/testthat/test_assess_news_current.R
@@ -1,7 +1,7 @@
-test_source_1 <- pkg_ref("test_package_1")
-assess_source_1 <- assess(test_source_1)
-test_source_2 <- pkg_ref("test_package_2")
-assess_source_2 <- assess(test_source_2)
+test_source_1 <- pkg_ref("./test_package_1")
+assess_source_1 <- pkg_assess(test_source_1)
+test_source_2 <- pkg_ref("./test_package_2")
+assess_source_2 <- pkg_assess(test_source_2)
 
 test_that("assess_news_current returns expected result for source packages", {
   # TODO: Add other pkg_ref types


### PR DESCRIPTION
Following PR #117, I had somewhat disregarded maintenance of unit tests. I went through and tried to resolve as many as possible.

At this point I think that most of the current test cases are passing again. The only exception is the `bugs_status` tests. So far today I think I've exceeded my allowance for public github api requests, so it's now throwing errors, but I think it should be fine otherwise. However, I think we will have to look into spoofing the api endpoint so that we can decouple our tests from GitHub. 

For now I've disabled this test until we have something more reliable in the hopes of soon getting us back on track with some continuous integration to help with code review. 

I also took the liberty of removing some legacy tests we had in there from early on in the project. These were entirely commented out without any hope of reintegrating them, so I see no problem with removing them.  