### PR TITLE
Update roxygen function description for pkg_score

### DIFF
--- a/R/pkg_score.R
+++ b/R/pkg_score.R
@@ -1,8 +1,7 @@
 #' Score a package assement, collapsing results into a single numeric
 #'
-#' Scores reflect the adherence to best practices. Scores always range from 0
-#' (worst-) to 1 (best- practice), and can then be used to consistently evaluate
-#' the risk involved with using a package.
+#' pkg_score() calculates the risk involved with using a package. Risk ranges
+#' from 0 (low-risk) to 1 (high-risk).
 #'
 #' @param x A \code{pkg_metric} object, whose subclass is used to choose the
 #'   appropriate scoring method for the atomic metric metadata. Optionally, a

--- a/man/pkg_score.Rd
+++ b/man/pkg_score.Rd
@@ -26,9 +26,8 @@ A numeric value if a single \code{pkg_metric} is provided, or a
   returned as numeric values when a \code{\link[tibble]{tibble}} is provided.
 }
 \description{
-Scores reflect the adherence to best practices. Scores always range from 0
-(worst-) to 1 (best- practice), and can then be used to consistently evaluate
-the risk involved with using a package.
+pkg_score() calculates the risk involved with using a package. Risk ranges
+from 0 (low-risk) to 1 (high-risk).
 }
 \examples{
 # scoring a single assessment


### PR DESCRIPTION
`pkg_score()` now calculates the risk of using a package (rather than its quality). This PR updates the roxygen comments for this function accordingly.