### PR TITLE
modified the paring of the bug url to grab the last domain before the…

### DIFF
--- a/R/pkg_ref_cache_bug_reports_host.R
+++ b/R/pkg_ref_cache_bug_reports_host.R
@@ -12,5 +12,5 @@ pkg_ref_cache.bug_reports_host <- function(x, ...) {
 #' @importFrom urltools host_extract domain
 pkg_ref_cache.bug_reports_host.default <- function(x, ...) {
   if (is.null(x$bug_reports_url)) return(NULL)
-  host_extract(domain(x$bug_reports_url))$host
+  sapply(strsplit(domain(x$bug_reports_url), "\\."), function(dm) dm[length(dm)-1])
 }

--- a/R/pkg_ref_cache_bug_reports_host.R
+++ b/R/pkg_ref_cache_bug_reports_host.R
@@ -9,7 +9,7 @@ pkg_ref_cache.bug_reports_host <- function(x, ...) {
 
 
 
-#' @importFrom urltools host_extract domain
+#' @importFrom urltools domain
 pkg_ref_cache.bug_reports_host.default <- function(x, ...) {
   if (is.null(x$bug_reports_url)) return(NULL)
   sapply(strsplit(domain(x$bug_reports_url), "\\."), function(dm) dm[length(dm)-1])


### PR DESCRIPTION
… TLD, this should be more robust to bug urls that use a subdomain instead of domain+path. I opted to keep the same intended behavior because the bugs_url_host is used for S3 dispatch of `scrape_bug_reports`. This is in reference to #92 