### PR TITLE
use remote dependency webmockr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Suggests:
     rmarkdown,
     dplyr,
     magrittr,
-    testthat,
-    webmockr
+    testthat
+Remotes:
+    ropensci/webmockr
 VignetteBuilder: knitr
 Config/testthat/edition: 3

--- a/tests/testthat/setup_mock_web_requests.R
+++ b/tests/testthat/setup_mock_web_requests.R
@@ -76,7 +76,8 @@ build_downloads <- function(downloads = NULL, pkg_name = "temp") {
         "Content-Encoding" = "UTF-8"))
 
 # github bugreports via github's repo issues api
-stub_request("get", uri_regex = "api\\.github\\.com/repos/[^/]+/[^/]+/issues\\?.+") %>%
+stub_request("get", uri_regex = "api\\.github\\.com/repos/[^/]+/[^/]+/issues") %>%
+  wi_th(query = list(state = "all", per_page = "30")) %>%
   to_return(
     body = file("./test_webmocks/data/github_repo_issues_api_response.json"),
     headers = list("Content-Type" = "application/json"))

--- a/tests/testthat/test_riskmetric_remotes.R
+++ b/tests/testthat/test_riskmetric_remotes.R
@@ -1,0 +1,5 @@
+test_that("webmockr GitHub remote dependency has been replaced by CRAN release v0.7 when available", {
+  ap <- available.packages(repos = "cloud.r-project.org")
+  CRAN_webmockr_version <- ap[ap[,"Package"] == "webmockr", "Version"]
+  expect_true(CRAN_webmockr_version < package_version("0.7"))
+})


### PR DESCRIPTION
- updating github issues webmock
- switch to remote webmockr dependency
- add test for upcoming webmockr release