### PR TITLE
[R CMD check fix] moving jsonlite to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Imports:
     BiocManager,
     cranlogs,
     covr,
-    jsonlite,
     vctrs,
     pillar,
     tibble,
@@ -42,7 +41,8 @@ Suggests:
     dplyr,
     magrittr,
     testthat, 
-    webmockr
+    webmockr,
+    jsonlite
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Config/testthat/edition: 3


### PR DESCRIPTION
`jsonlite` is unused in package code, and only used in tests. Moving to `Suggests` section of depends.