### PR TITLE
Issue 236: modify the aggregation of package metrics into the package score

### DIFF
--- a/R/assess_dependencies.R
+++ b/R/assess_dependencies.R
@@ -68,14 +68,23 @@ assess_dependencies.pkg_bioc_remote <- function(x, ...){
 
 #' Score a package for dependencies
 #'
-#' Returns the total number dependencies
+#' Calculates a regularized score based on the number of dependencies a package has.
+#' Convert the number of dependencies \code{NROW(x)} into a validation
+#' score [0,1] \deqn{ 1 - 1 / (1 + exp(-0.5 * (NROW(x) + 4))) }
+#'
+#' The scoring function is the classic logistic curve \deqn{ / (1 + exp(-k(x-x[0])) }
+#' \eqn{x = NROW(x)}, sigmoid midpoint is 5 reverse dependencies, ie. \eqn{x[0] = 4},
+#' and logistic growth rate of \eqn{k = 0.5}.
+#'
+#' \deqn{ 1 - 1 / (1 + exp(NROW(x)-4)) }
 #'
 #' @eval roxygen_score_family("dependencies")
-#' @return A \code{numeric}
+#' @return numeric value between \code{0} (high number of  dependencies) and
+#'   \code{1} (low number of dependencies)
 #'
 #' @export
 metric_score.pkg_metric_dependencies <- function(x, ...) {
-  NROW(x)
+  1 - 1/(1 + exp(-0.5 * (NROW(x) - 4)))
 }
 attributes(metric_score.pkg_metric_dependencies)$label <-
   "The number of package dependencies"

--- a/R/assess_exported_namespace.R
+++ b/R/assess_exported_namespace.R
@@ -39,14 +39,24 @@ assess_exported_namespace.pkg_source <- function(x, ...) {
 
 #' Score a package for the number of exported objects
 #'
-#' Count the number of exported objects (excluding S3Methods) and divide by 100
+#' Score a package for the number of exported objects it has; regularized
+#' Convert the number of exported objects \code{length(x)} into a validation
+#' score [0,1] \deqn{ 1 / (1 + exp(-0.5 * (sqrt(length(x)) + sqrt(5)))) }
+#'
+#' The scoring function is the classic logistic curve \deqn{
+#' 1 / (1 + exp(-k(x-x[0])) } with a square root scale for the number of exported objects
+#' \eqn{x = sqrt(length(x))}, sigmoid midpoint is 25 exported objects, ie. \eqn{x[0] =
+#' sqrt(5)}, and logistic growth rate of \eqn{k = 0.25}.
+#'
+#' \deqn{ 1 / (1 + exp(-0.25 * sqrt(length(x))-sqrt(25))) }
 #'
 #' @eval roxygen_score_family("exported_namespace")
-#' @return numeric value
+#' @return numeric value between \code{0} (high number of exported objects) and
+#'   \code{1} (low number of exported objects)
 #'
 #' @export
 metric_score.pkg_metric_exported_namespace <- function(x, ...) {
-  length(x)
+  1 - 1 / (1 + exp(-0.25 * (sqrt(length(x)) - sqrt(25))))
 }
 
 attributes(metric_score.pkg_metric_exported_namespace)$label <-

--- a/R/assess_r_cmd_check.R
+++ b/R/assess_r_cmd_check.R
@@ -1,8 +1,8 @@
-#' Assess a package's results from running R CMD check 
+#' Assess a package's results from running R CMD check
 #'
 #' @eval roxygen_assess_family(
 #'   "r_cmd_check",
-#'   "Tally of errors, warnings and notes from running R CMD check locally", 
+#'   "Tally of errors, warnings and notes from running R CMD check locally",
 #'   dontrun = TRUE)
 
 #' @export
@@ -29,27 +29,29 @@ assess_r_cmd_check.pkg_source <- function(x, ...) {
 #' @export
 assess_r_cmd_check.pkg_cran_remote <- function(x, ...) {
   as_pkg_metric_todo(pkg_metric(class = "pkg_metric_r_cmd_check",
-                                message = "Assessment of R CMD check on remote 
-                                pkg refs is not yet implemented but will be in 
+                                message = "Assessment of R CMD check on remote
+                                pkg refs is not yet implemented but will be in
                                 the future"))
 }
 
 #' @export
 assess_r_cmd_check.pkg_bioc_remote <- function(x, ...) {
   as_pkg_metric_todo(pkg_metric(class = "pkg_metric_r_cmd_check",
-                                "Assessment of R CMD check on remote pkg refs 
+                                "Assessment of R CMD check on remote pkg refs
                                 is not yet implemented but will be in the future"))
 }
 
 #' Score a package based on R CMD check results run locally
 #'
-#' The scoring function is 
+#' The scoring function is the weighted sum of notes (0.1), errors (1) and warnings (0.25), with a maximum score of 1 (no errors, notes or warnings)
+#' and a minimum score of 0.
+#' Essentially, the metric will allow up to 10 notes, 1 error or 4 warnings before returning the lowest score of 0
 #' @eval roxygen_score_family("r_cmd_check", dontrun = TRUE)
 #' @return A weighted sum of errors and warnings of all tests preformed
 #'
 #' @export
 metric_score.pkg_metric_r_cmd_check <- function(x, ...) {
-  sum(x*c(0.1, 1, 0.5))
+  1 - min(c(sum(x*c(0.1, 1, 0.25)), 1))
 }
 attributes(metric_score.pkg_metric_r_cmd_check)$label <-
   "A weighted sum of errors/warnings/notes from R CMD Check"

--- a/R/assess_remote_checks.R
+++ b/R/assess_remote_checks.R
@@ -4,7 +4,7 @@
 #'   "remote_checks",
 #'   "Tally of R CMD check results run on differnt OS flavors by BioC or CRAN",
 #'   dontrun = TRUE)
-#'   
+#'
 #' @export
 assess_remote_checks <- function(x, ...) {
   UseMethod("assess_remote_checks")
@@ -14,8 +14,8 @@ attributes(assess_remote_checks)$label <- "Number of OS flavors that passed/warn
 
 #' @export
 assess_remote_checks.default <- function(x, ...) {
-  as_pkg_metric_na(pkg_metric(class="pkg_metric_remote_checks", 
-                              message="Package is not a CRAN or BioC reference so there 
+  as_pkg_metric_na(pkg_metric(class="pkg_metric_remote_checks",
+                              message="Package is not a CRAN or BioC reference so there
                               are no CRAN/BioC checks to assess"))
 }
 
@@ -23,7 +23,7 @@ assess_remote_checks.default <- function(x, ...) {
 assess_remote_checks.pkg_cran_remote <- function(x, ...) {
   pkg_metric_eval(class = "pkg_metric_remote_checks",{
     table(factor(x$remote_checks[["Status"]],
-                 levels = c("OK","WARN","ERROR", "NOTE", "FAIL"))) 
+                 levels = c("OK","WARN","ERROR", "NOTE", "FAIL")))
              })
 }
 
@@ -43,7 +43,7 @@ assess_remote_checks.pkg_bioc_remote <- function(x, ...) {
 #'
 #' @export
 metric_score.pkg_metric_remote_checks <- function(x, ...) {
-  unname((x["OK"] + (x[grepl("WARN", names(x))] *0.5))/sum(x))
+  unname((x["OK"] + (x[grepl("NOTE", names(x))] *0.75) + (x[grepl("WARN", names(x))] *0.5))/sum(x))
 }
 attributes(metric_score.pkg_metric_remote_checks)$label <-
   "Weighted sum of OS flavor R CMD check results"

--- a/R/assess_reverse_dependencies.R
+++ b/R/assess_reverse_dependencies.R
@@ -27,14 +27,14 @@ attr(assess_reverse_dependencies, "label") <- "List of reverse dependencies a pa
 #'
 #' Score a package for the number of reverse dependencies it has; regularized
 #' Convert the number of reverse dependencies \code{length(x)} into a validation
-#' score [0,1] \deqn{ 1 - 1 / (1 + exp(-0.5 * (sqrt(length(x)) + sqrt(5)))) }
+#' score [0,1] \deqn{ 1 / (1 + exp(-0.5 * (sqrt(length(x)) + sqrt(5)))) }
 #'
 #' The scoring function is the classic logistic curve \deqn{
 #' 1 / (1 + exp(-k(x-x[0])) } with a square root scale for the number of reverse dependencies
 #' \eqn{x = sqrt(length(x))}, sigmoid midpoint is 5 reverse dependencies, ie. \eqn{x[0] =
 #' sqrt(5)}, and logistic growth rate of \eqn{k = 0.5}.
 #'
-#' \deqn{ 1 - 1 / (1 + exp(sqrt(length(x))-sqrt(1.5e5))) }
+#' \deqn{ 1 / (1 + exp(sqrt(length(x))-sqrt(5))) }
 
 #' @eval roxygen_score_family("reverse_dependencies", dontrun = TRUE)
 #' @return numeric value between \code{1} (high number of reverse dependencies) and

--- a/R/assess_reverse_dependencies.R
+++ b/R/assess_reverse_dependencies.R
@@ -25,12 +25,24 @@ attr(assess_reverse_dependencies, "label") <- "List of reverse dependencies a pa
 
 #' Scoring method for number of reverse dependencies a package has
 #'
+#' Score a package for the number of reverse dependencies it has; regularized
+#' Convert the number of reverse dependencies \code{length(x)} into a validation
+#' score [0,1] \deqn{ 1 - 1 / (1 + exp(-0.5 * (sqrt(length(x)) + sqrt(5)))) }
+#'
+#' The scoring function is the classic logistic curve \deqn{
+#' 1 / (1 + exp(-k(x-x[0])) } with a square root scale for the number of reverse dependencies
+#' \eqn{x = sqrt(length(x))}, sigmoid midpoint is 5 reverse dependencies, ie. \eqn{x[0] =
+#' sqrt(5)}, and logistic growth rate of \eqn{k = 0.5}.
+#'
+#' \deqn{ 1 - 1 / (1 + exp(sqrt(length(x))-sqrt(1.5e5))) }
+
 #' @eval roxygen_score_family("reverse_dependencies", dontrun = TRUE)
-#' @return The count of reverse dependencies a package has
+#' @return numeric value between \code{1} (high number of reverse dependencies) and
+#'   \code{0} (low number of reverse dependencies)
 #'
 #' @export
 metric_score.pkg_metric_reverse_dependencies <- function(x,...){
-  log10(length(x)+0.1)
+  1 / (1 + exp(-0.5 * (sqrt(length(x)) - sqrt(5))))
 }
 
 attributes(metric_score.pkg_metric_reverse_dependencies)$label <-

--- a/R/assess_reverse_dependencies.R
+++ b/R/assess_reverse_dependencies.R
@@ -34,7 +34,7 @@ attr(assess_reverse_dependencies, "label") <- "List of reverse dependencies a pa
 #' \eqn{x = sqrt(length(x))}, sigmoid midpoint is 5 reverse dependencies, ie. \eqn{x[0] =
 #' sqrt(5)}, and logistic growth rate of \eqn{k = 0.5}.
 #'
-#' \deqn{ 1 / (1 + exp(sqrt(length(x))-sqrt(5))) }
+#' \deqn{ 1 / (1 + -0.5 * exp(sqrt(length(x)) - sqrt(5))) }
 
 #' @eval roxygen_score_family("reverse_dependencies", dontrun = TRUE)
 #' @return numeric value between \code{1} (high number of reverse dependencies) and

--- a/tests/testthat/test_metric_score_range.R
+++ b/tests/testthat/test_metric_score_range.R
@@ -1,0 +1,21 @@
+test_that("scored assessments are all between [0,1]", {
+  pkg_scores_objs <- list(
+    # score_cran_remote_good,
+    # score_cran_remote_bad,
+    score_source_good
+    # score_source_bad,
+    # score_stdlib_install,
+    # score_stdlibs_install,
+    # score_pkg_missing
+  )
+  for (pkg_scores_i in pkg_scores_objs) {
+    pkg_metric_idx <- which(sapply(pkg_scores_i, function(x) any(class(x) %in% "pkg_score")))
+    expect_true({
+      metrics_are_valid <- vapply(pkg_scores_i[pkg_metric_idx],
+                                  function(i) all(na.omit(i)<=1 & na.omit(i) >= 0),
+                                  logical(1L))
+
+      all(metrics_are_valid)
+    })
+  }
+})


### PR DESCRIPTION
This PR addresses issue #236. 
1. It corrects a number of `metric_score` functions so that they return a value between [0,1]
2. creates a unit test which checks that all metrics are between [0,1], while ignoring NAs