### PR TITLE
added metric score method for pkg_metric_error class

### DIFF
--- a/R/metric_score.R
+++ b/R/metric_score.R
@@ -49,6 +49,9 @@ metric_score_condition.pkg_metric_na <- function(x, ...) {
   structure(NA_real_, class = c("pkg_score_na", "numeric"))
 }
 
+metric_score_condition.pkg_metric_error <- function(x, ...) {
+  structure(NA_real_, class = c("pkg_score_error", "numeric"))
+}
 
 metric_score_condition.pkg_metric_todo <- function(x, ...) {
   structure(NA_real_, class = c("pkg_score_todo", "numeric"))


### PR DESCRIPTION
This prevents the warning message: #241 

> 'Warning message:
> In error_handler(x, ...) :
> no available scoring algorithm for metric of class "pkg_metric_error", returning default score of 0.'