### PR TITLE
Metric weights 293

### DIFF
--- a/R/pkg_ref_cache.R
+++ b/R/pkg_ref_cache.R
@@ -122,7 +122,7 @@ available_pkg_ref_fields <- function(x) {
 #' @family package reference cache
 #'
 #' @rdname riskmetric_metadata_caching
-#' @keyworks internal
+#' @keywords internal
 #' @noRd
 pkg_ref_cache <- function(x, name, ..., .class = as.character(name)) {
   UseMethod("pkg_ref_cache", structure(list(), class = .class))

--- a/R/pkg_score.R
+++ b/R/pkg_score.R
@@ -70,13 +70,22 @@ pkg_score.tbl_df <- function(x, ..., error_handler = score_error_default) {
 pkg_score.list_of_pkg_metric <- function(x, ...,
     error_handler = score_error_default) {
 
-  lapply(x, function(xi) {
+  metrics <- lapply(x, function(xi) {
     s <- metric_score(xi, error_handler = error_handler)
     metric_score_s3_fun <- firstS3method("metric_score", class(xi))
     attr(s, "label") <- attr(metric_score_s3_fun, "label")
     class(s) <- c("pkg_score", class(s))
     s
   })
+
+  ignore_cols <- c("package", "version", "pkg_ref")
+  metrics[["pkg_score"]] <- summarize_scores(metrics[!names(metrics) %in% ignore_cols], ...)
+
+  # reorder columns so that metadata columns come first
+  pkg_cols <- intersect(names(metrics), c("package", "version", "pkg_ref", "pkg_score"))
+  metrics <- metrics[c(pkg_cols, setdiff(names(metrics), pkg_cols))]
+
+  return(metrics)
 }
 
 

--- a/R/pkg_score.R
+++ b/R/pkg_score.R
@@ -65,7 +65,6 @@ pkg_score.tbl_df <- function(x, ..., error_handler = score_error_default) {
 }
 
 
-
 #' @export
 pkg_score.list_of_pkg_metric <- function(x, ...,
     error_handler = score_error_default) {

--- a/R/summarize_scores.R
+++ b/R/summarize_scores.R
@@ -39,7 +39,7 @@ summarize_scores.data.frame <- function(data, weights = NULL) {
   # calculate 'quality' and subtract from 1 to get 'risk'
   qual <- rowSums(data * t(apply(data, 1, standardize_weights, weights=weights)), na.rm = T)
   risk <- 1 - qual
-
+  attr(risk,"label") <- "Summarized risk score from 0 (low) to 1 (high)."
   risk
 }
 
@@ -50,7 +50,9 @@ summarize_scores.list <- function(data, weights = NULL) {
 
   # perform checks and standardize weights
   weights <- standardize_weights(data, weights)
-  1 - sum(as.numeric(data[names(weights)]) * weights, na.rm = TRUE)
+  risk <- 1 - sum(as.numeric(data[names(weights)]) * weights, na.rm = TRUE)
+  attr(risk,"label") <- "Summarized risk score from 0 (low) to 1 (high)."
+  return(risk)
 }
 
 # Set the default weight of each metric to 1.

--- a/R/summarize_scores.R
+++ b/R/summarize_scores.R
@@ -34,10 +34,10 @@ summarize_scores.data.frame <- function(data, weights = NULL) {
     weights <- add_default_weights(data)
 
   # perform checks and standardize weights
-  weights <- standardize_weights(data, weights)
+  #weights <- standardize_weights(data, weights)
 
   # calculate 'quality' and subtract from 1 to get 'risk'
-  qual <- colSums(apply(data[names(weights)], 1L, `*`, weights), na.rm = TRUE)
+  qual <- rowSums(data * t(apply(data, 1, standardize_weights, weights=weights)), na.rm = T)
   risk <- 1 - qual
 
   risk
@@ -83,8 +83,10 @@ standardize_weights <- function(data, weights) {
   check_weights(weights)
 
   # re-weight for fields that are in the dataset
+  weights[is.na(data)] <- 0
   weights <- weights[which(names(weights) %in% names(data))]
 
   # standardize weights from 0 to 1
   weights <- weights / sum(weights, na.rm = TRUE)
+  return(weights)
 }

--- a/man/pkg_assess.Rd
+++ b/man/pkg_assess.Rd
@@ -43,25 +43,25 @@ assessment applied.
 \section{Assessment function catalog}{
 
 \describe{
-\item{\code{\link{assess_last_30_bugs_status}}}{vector indicating whether BugReports status is closed}
-\item{\code{\link{assess_covr_coverage}}}{Package unit test coverage}
-\item{\code{\link{assess_size_codebase}}}{number of lines of code base}
-\item{\code{\link{assess_export_help}}}{exported objects have documentation}
-\item{\code{\link{assess_r_cmd_check}}}{Package check results}
 \item{\code{\link{assess_dependencies}}}{Package dependency footprint}
-\item{\code{\link{assess_reverse_dependencies}}}{List of reverse dependencies a package has}
-\item{\code{\link{assess_license}}}{software is released with an acceptable license}
-\item{\code{\link{assess_has_maintainer}}}{a vector of associated maintainers}
-\item{\code{\link{assess_remote_checks}}}{Number of OS flavors that passed/warned/errored on R CMD check}
-\item{\code{\link{assess_exported_namespace}}}{Objects exported by package}
-\item{\code{\link{assess_has_website}}}{a vector of associated website urls}
-\item{\code{\link{assess_downloads_1yr}}}{number of downloads in the past year}
-\item{\code{\link{assess_has_news}}}{number of discovered NEWS files}
-\item{\code{\link{assess_has_vignettes}}}{number of discovered vignettes files}
 \item{\code{\link{assess_has_examples}}}{proportion of discovered function files with examples}
+\item{\code{\link{assess_remote_checks}}}{Number of OS flavors that passed/warned/errored on R CMD check}
+\item{\code{\link{assess_has_news}}}{number of discovered NEWS files}
+\item{\code{\link{assess_last_30_bugs_status}}}{vector indicating whether BugReports status is closed}
+\item{\code{\link{assess_export_help}}}{exported objects have documentation}
+\item{\code{\link{assess_downloads_1yr}}}{number of downloads in the past year}
+\item{\code{\link{assess_has_website}}}{a vector of associated website urls}
 \item{\code{\link{assess_has_source_control}}}{a vector of associated source control urls}
-\item{\code{\link{assess_has_bug_reports_url}}}{presence of a bug reports url in repository}
+\item{\code{\link{assess_license}}}{software is released with an acceptable license}
 \item{\code{\link{assess_news_current}}}{NEWS file contains entry for current version number}
+\item{\code{\link{assess_covr_coverage}}}{Package unit test coverage}
+\item{\code{\link{assess_r_cmd_check}}}{Package check results}
+\item{\code{\link{assess_exported_namespace}}}{Objects exported by package}
+\item{\code{\link{assess_has_maintainer}}}{a vector of associated maintainers}
+\item{\code{\link{assess_has_vignettes}}}{number of discovered vignettes files}
+\item{\code{\link{assess_size_codebase}}}{number of lines of code base}
+\item{\code{\link{assess_has_bug_reports_url}}}{presence of a bug reports url in repository}
+\item{\code{\link{assess_reverse_dependencies}}}{List of reverse dependencies a package has}
 }
 }
 


### PR DESCRIPTION
first draft for fixing metric weights errors.

The problem: 

If a metric was `NA` it was essentially imputed to `0` unless you explicitly set the it's weight to `0`.  The proposed solution: Set metric weight to `0` if its score is `NA`.  

Some caveats:
1) The solution requires that we compute weights and scores per package because a collection of packages could have different patterns of `NAs`. e.g. scoring packages from different sources.
2) What if a user explicitly sets a weight but the metric is missing? Currently, `standardize_weights` silently resets the weight to `0`. This should at the least issue a warning.
3) If a user sets weights for a subset of metrics should `pkg_score`: 1) error, 2) warn, or 3) only compute a summarized score for the metrics with a weight? 
  1) very conservative and will break pipelines if/when metrics are added
  2) the middle ground?
  3) most backward compatible but user could be unknowingly omitting metrics upon upgrade of `riskemtric`

This is still a work in progress, but i think it is baked enough to discuss.



