### PR TITLE
ignore incomplete final line

### DIFF
--- a/R/pkg_ref_cache_news.R
+++ b/R/pkg_ref_cache_news.R
@@ -64,7 +64,7 @@ news_from_dir <- function(path) {
         content[[i]] <- .tools()$.news_reader_default(f)
       } else if (tolower(tools::file_ext(f)) == "md") {
         # NOTE: should we do validation of markdown format?
-        content[[i]] <- readLines(f)
+        content[[i]] <- readLines(f, warn = FALSE)
       }
       valid[[i]] <- TRUE
     }, error = function(e) {


### PR DESCRIPTION
Warning message is returned, when running "assess_has_news" on packages, that do not have empty line at the end of file:

![image](https://github.com/pharmaR/riskmetric/assets/10699712/de0c3045-269b-46b9-8c97-f523a204ec39)

I have tested it on packages "ini", "viridisLite". Below is the code for reproducing the warning messages.

```
# === load riskmetric library
library("riskmetric")
library("magrittr")

# === create testing environment
dir.create(paste0(tempdir(), "/test_riskmetric"))
dir.create(paste0(tempdir(), "/test_riskmetric/source"))
dir.create(paste0(tempdir(), "/test_riskmetric/library"))
dir.create(paste0(tempdir(), "/test_riskmetric/downloads"))

# === download and unpack files
pkgs <- c("viridisLite", "ini")

# === install packages
install.packages(pkgs, lib = paste0(tempdir(), "/test_riskmetric/library"))
list.files(paste0(tempdir(), "/test_riskmetric/library"), recursive = TRUE)

pkg_ref(x = paste0(tempdir(), "/test_riskmetric/library/", pkgs[1])) %>% 
  pkg_assess(assessments = riskmetric::all_assessments()["assess_has_news"]) %>% 
  pkg_score()

pkg_ref(x = paste0(tempdir(), "/test_riskmetric/library/", pkgs[2])) %>% 
  pkg_assess(assessments = riskmetric::all_assessments()["assess_has_news"]) %>% 
  pkg_score()
```

Simplest fix, would be to to use `readLines(., warn = FALSE)`.