### PR TITLE
Limit assess_size_codebase to only .R files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Risk Metrics to Evaluating R Packages
 Description: Facilities for assessing R packages against a number of metrics to 
     help quantify their robustness.
-Version: 0.2.4.9000
+Version: 0.2.4.9001
 Authors@R: c(
     person("R Validation Hub", role = c("aut"), email = "psi.aims.r.validation@gmail.com"),
     person("Doug", "Kelkhoff", role = c("aut"), email = "doug.kelkhoff@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# riskmetric (development version)
+
+- Fix bug with assessing source packages that have non-R files in the R directory ([#362](https://github.com/pharmaR/riskmetric/issues/362))
+
 # riskmetric 0.2.4
 
 - Fix CRAN errors.

--- a/R/assess_size_codebase.R
+++ b/R/assess_size_codebase.R
@@ -41,7 +41,12 @@ assess_size_codebase.pkg_install <- function(x, ...) {
 assess_size_codebase.pkg_source <- function(x, ...) {
   pkg_metric_eval(class = "pkg_metric_size_codebase", {
     # create character vector of function files
-    files <- list.files(path = file.path(x$path, "R"), full.names = T)
+    files <- list.files(
+      path = file.path(x$path, "R"),
+      pattern = "\\.R$",
+      full.names = TRUE,
+      ignore.case = TRUE
+    )
 
     # define the function for counting code base
     count_lines <- function(x){


### PR DESCRIPTION
Closes #362 

## Description

This change is related to assess_size_codebase metric, when it is being assessed on a local source code. It currently fails for packages that have .rda files inside the R folder. Examples: [acss.data](https://cran.r-project.org/web/packages/acss.data/index.html), [bayesPop](https://cran.r-project.org/web/packages/bayesPop/index.html).

The proposed change is to only list files with .R extension. 