### PR TITLE
Updates to resolve CRAN comments in R-devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,6 @@ jobs:
           - {os: ubuntu-22.04,   r: 'oldrel-1'}
           - {os: ubuntu-22.04,   r: 'oldrel-2'}
           - {os: ubuntu-22.04,   r: 'oldrel-3'}
-          - {os: ubuntu-22.04,   r: 'oldrel-4'}
           - {os: ubuntu-20.04,   r: 'release'}
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Risk Metrics to Evaluating R Packages
 Description: Facilities for assessing R packages against a number of metrics to 
     help quantify their robustness.
-Version: 0.2.4.9001
+Version: 0.2.5
 Authors@R: c(
     person("R Validation Hub", role = c("aut"), email = "psi.aims.r.validation@gmail.com"),
     person("Doug", "Kelkhoff", role = c("aut"), email = "doug.kelkhoff@gmail.com"),

--- a/R/assess_dependencies.R
+++ b/R/assess_dependencies.R
@@ -121,7 +121,7 @@ get_package_dependencies <- function(name, repo){
 parse_dcf_dependencies <- function(path){
   dcf <- read.dcf(file.path(path, "DESCRIPTION"), all=TRUE)
   dcf <- dcf[colnames(dcf) %in% c("LinkingTo","Imports", "Depends")]
-  dcf <- sapply(dcf, strsplit, strsplit, split=",")
+  dcf <- sapply(dcf, strsplit, split=",")
   dcf <- lapply(dcf, trimws)
   deps <- data.frame(package=unlist(dcf),
                      type=rep(names(dcf), sapply(dcf, length)),

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-## riskmetric 0.2.4
+## riskmetric 0.2.5
 
 Resolved issues with CRAN checks.
 


### PR DESCRIPTION
From [R-devel news](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html):

> grep(), strsplit() and similar took non-TRUE values of their logical arguments as FALSE, but these were almost always mistakes and are now reported as NA.

There was an error in the dependency check for source packages. and removing the extra `strsplit` fixes it