### PR TITLE
Remove package_version

### DIFF
--- a/R/pkg_ref_cache_archive_release_date.R
+++ b/R/pkg_ref_cache_archive_release_date.R
@@ -18,8 +18,7 @@ pkg_ref_cache.archive_release_dates.pkg_cran_remote <- function(x, name, ...) {
 
   text <- unlist(strsplit(xml2::xml_text(node), "\n"))
   db   <- do.call(rbind, strsplit(text[-1], "\\s+"))
-  version <- package_version(gsub(paste0(x$name, "_(.*)\\.tar\\.gz"), "\\1", db[,2]))
-  version <- as.character(version)
+  version <- gsub(paste0(x$name, "_(.*)\\.tar\\.gz"), "\\1", db[,2])
   date  <- db[,3]
   cbind(name = x$name, version, date)
 

--- a/R/pkg_ref_class.R
+++ b/R/pkg_ref_class.R
@@ -164,7 +164,7 @@ pkg_source <- function(x) {
   name <- unname(desc[,"Package"])
 
   new_pkg_ref(name,
-              version = package_version(desc[,"Version"][[1]]),
+              version = desc[,"Version"][[1]],
               path = normalizePath(x),
               source = "pkg_source")
 }


### PR DESCRIPTION
Removes the `package_version` casting. 

This will enable it to work on old versions of packages before there was a requirement on what was allowed as version number. 
Note: R doesn't force semantic versioning (three numbers). 

Closes #364