### PR TITLE
Check that suggested packages used on tests are available

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,8 @@
-library(testthat)
-library(riskmetric)
+if (requireNamespace("testthat", quietly = TRUE) && requireNamespace("webmockr", quietly = TRUE) && requireNamespace("jsonlite", quietly = TRUE) && requireNamespace("magrittr", quietly = TRUE)  && requireNamespace("withr", quietly = TRUE)) {
+  library(testthat)
+  library(riskmetric)
 
-options(repos = "fake-cran.fake-r-project.org")
+  options(repos = "fake-cran.fake-r-project.org")
 
-test_check("riskmetric")
+  test_check("riskmetric")
+}


### PR DESCRIPTION
Many suggested packages are used unconditionally on tests:
magrittr pipe is used  in tests/testthat/setup_mock_web_requests.R
withr in tests/testthat/setup_test_packages.R
webmockr is used  in tests/testthat/setup_mock_web_requests.R
jsonlite is used  in tests/testthat/setup_mock_web_requests.R

This PR checks they are available before running any test