### PR TITLE
Vignette improvements

### DIFF
--- a/vignettes/extending-riskmetric.Rmd
+++ b/vignettes/extending-riskmetric.Rmd
@@ -240,23 +240,23 @@ assessment toolkit.
 
 ```{r}
 library(dplyr)
-assesments <- pkg_ref(c("riskmetric", "utils", "tools")) %>%
+assessments <- pkg_ref(c("riskmetric", "utils", "tools")) %>%
   as_tibble() %>%
   pkg_assess(c(all_assessments(), assess_name_first_letter))
-assesments
+assessments
 ```
 
 Our scoring function will automatically get picked up and used by the score
 method.
 
 ```{r, warning = FALSE}
-pkg_score(assesments)
+pkg_score(assessments)
 ```
 
 and we can define our own summarizing weights by passing a named list to `pkg_score`.
 
 ```{r, warning = FALSE}
-pkg_score(assesments, weights = c(has_website = 1, name_first_letter = 1))
+pkg_score(assessments, weights = c(has_website = 1, name_first_letter = 1))
 ```
 
 Of course you can do any downstream processing of the resulting `tibble` if

--- a/vignettes/extending-riskmetric.Rmd
+++ b/vignettes/extending-riskmetric.Rmd
@@ -240,28 +240,23 @@ assessment toolkit.
 
 ```{r}
 library(dplyr)
-pkg_ref(c("riskmetric", "utils", "tools")) %>%
+assesments <- pkg_ref(c("riskmetric", "utils", "tools")) %>%
   as_tibble() %>%
   pkg_assess(c(all_assessments(), assess_name_first_letter))
+assesments
 ```
 
 Our scoring function will automatically get picked up and used by the score
 method.
 
 ```{r, warning = FALSE}
-pkg_ref(c("riskmetric", "utils", "tools")) %>%
-  as_tibble() %>%
-  pkg_assess(c(all_assessments(), assess_name_first_letter)) %>%
-  pkg_score()
+pkg_score(assesments)
 ```
 
 and we can define our own summarizing weights by passing a named list to `pkg_score`.
 
 ```{r, warning = FALSE}
-pkg_ref(c("riskmetric", "utils", "tools")) %>%
-  as_tibble() %>%
-  pkg_assess(c(all_assessments(), assess_name_first_letter)) %>%
-  pkg_score(weights = c(has_news = 1, name_first_letter = 1))
+pkg_score(assesments, weights = c(has_website = 1, name_first_letter = 1))
 ```
 
 Of course you can do any downstream processing of the resulting `tibble` if


### PR DESCRIPTION
This reduces calculation of some steps on the vignette.
Locally it was failing because `has_news` was not available. I changed to a different metric. 
I think `pkg_score` would benefit from some defensive programming (checking that the tibble has more than 1 column), but I haven't pushed that change. 
