### PR TITLE
bugfix: assess_export_help.pkg_source

### DIFF
--- a/R/assess_export_help.R
+++ b/R/assess_export_help.R
@@ -28,7 +28,7 @@ assess_export_help.pkg_source <- function(x, ...) {
   pkg_metric_eval(class = "pkg_metric_export_help", {
     # ignore S3-dispatched methods
     lines <- readLines(paste0(x$path, "/NAMESPACE"), warn = FALSE)
-    export_lines <- grep("^export\\(|^exportMethods\\(", lines, value = TRUE)
+    export_lines <- grep("^export\\(|^exportMethod\\(", lines, value = TRUE)
     exports <- gsub(".*\\(([^)]+)\\).*", "\\1", export_lines)
     exports <- unlist(strsplit(exports, ",\\s*"))
 

--- a/R/assess_export_help.R
+++ b/R/assess_export_help.R
@@ -27,7 +27,11 @@ assess_export_help.pkg_remote <- function(x, ...) {
 assess_export_help.pkg_source <- function(x, ...) {
   pkg_metric_eval(class = "pkg_metric_export_help", {
     # ignore S3-dispatched methods
-    exports <- unname(unlist(pkgload::parse_ns_file(x$path)[c("exports","exportMethods")]))
+    lines <- readLines(paste0(x$path, "/NAMESPACE"), warn = FALSE)
+    export_lines <- grep("^export\\(|^exportMethods\\(", lines, value = TRUE)
+    exports <- gsub(".*\\(([^)]+)\\).*", "\\1", export_lines)
+    exports <- unlist(strsplit(exports, ",\\s*"))
+
     out <- exports %in% names(x$help_aliases)
     names(out) <- exports
     out


### PR DESCRIPTION
close #381 

The function `assess_export_help.pkg_source()` fails when the target package (i.e., the one being assessed) has dependencies that are not installed. This is due to the use of `pkgload::parse_ns_file()`, which attempts to evaluate `import()` and other namespace directives, thus requiring all dependencies to be present.

This makes the metric fragile and unsuitable for use in minimal environments (e.g., CI pipelines or isolated testing setups) where not all dependencies of a package are guaranteed to be installed.