### PR TITLE
remove deprecated ubuntu 20.04 from gha

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,6 @@ jobs:
           - {os: ubuntu-22.04,   r: 'oldrel-1'}
           - {os: ubuntu-22.04,   r: 'oldrel-2'}
           - {os: ubuntu-22.04,   r: 'oldrel-3'}
-          - {os: ubuntu-20.04,   r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
close #383 

Ubuntu 20.04 LTS actions runner image is now [deprecated](https://github.com/actions/runner-images/issues/11101).