### PR TITLE
Exporting metrics

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -1,0 +1,39 @@
+serialize_with_attributes <- function(x) {
+  if (is.list(x) && !is.null(names(x))) {
+    result <- list()
+    for (n in names(x)) {
+      result[[n]] <- serialize_with_attributes(x[[n]])
+    }
+    return(result)
+  }
+
+  # For atomic or S3 elements with attributes
+  val <- unclass(x)
+  attrs <- attributes(x)
+
+  # Sanitize attributes (no S3 objects inside)
+  if (!is.null(attrs)) {
+    for (a in names(attrs)) {
+      if (inherits(attrs[[a]], "AsIs") || is.factor(attrs[[a]])) {
+        attrs[[a]] <- as.character(attrs[[a]])
+      } else if (!is.atomic(attrs[[a]])) {
+        attrs[[a]] <- unclass(attrs[[a]])
+      }
+    }
+  }
+
+  list(
+    value = val,
+    attributes = attrs
+  )
+}
+
+
+export_json <- function(metrics, file = "PACKAGES.json") {
+  metrics_serialized <- serialize_with_attributes(metrics)
+  jsonlite::write_json(metrics_serialized, path = file, pretty = TRUE, auto_unbox = FALSE)
+}
+
+export_dcf <- function(metrics, file = "PACKAGES") {
+  write.dcf(metrics, file = file)
+}


### PR DESCRIPTION
PR to address #376 

Challenges:

1) exporting metrics directly to PACAKGES results on floating numbers with different accuracy (on a test case between 17 and 19 digits)
2) To recover the same object (aka `identical(metrics, metrics |> write() |> read())`) means restoring the labels and some attributes of the metrics:

```
attributes(metrics$downloads_1yr)
## $.recording
## $.recording$expr
## {
##     sum(x$downloads$count)
## }
## 
## $.recording$attributes
## NULL
## 
## $.recording$visible
## [1] TRUE
## 
## ...
```

